### PR TITLE
Fix invisibility in custom theme

### DIFF
--- a/history/src/widgets/right_sidebar.tsx
+++ b/history/src/widgets/right_sidebar.tsx
@@ -48,7 +48,7 @@ function RightSidebar2() {
 
   return (
     <div
-      className="h-full overflow-y-auto rn-clr-background-primary"
+      className="h-full overflow-y-auto rn-clr-background-primary relative z-10"
       onMouseDown={(e) => e.stopPropagation()}
     >
       {remData.length == 0 && (


### PR DESCRIPTION
I fixed a potential layer eclipse problem about custom theme. Back then It was totally invisible in custom theme due to z layer 

![220806-113952](https://user-images.githubusercontent.com/56161102/183230409-cf45531a-efe7-4f0c-b608-fb78163b6cf6.gif)

Do we need z-index to lower levels like `z-[1]`?
