### PR TITLE
Enable "Zen Mode" fading for the Tabs Plugin

### DIFF
--- a/tabs/src/widgets/tabs.tsx
+++ b/tabs/src/widgets/tabs.tsx
@@ -169,7 +169,8 @@ function TabsBar() {
         "overflow-x-auto overflow-y-hidden",
         "rn-clr-background-secondary",
         "flex gap-1 items-stretch",
-        "p-1 py-0 pl-4"
+        "p-1 py-0 pl-4",
+        "fade-on-hide-ui"
       )}
     >
       {tabs?.[0] && (


### PR DESCRIPTION
this should make the tabs bar fade when "Zen Mode" is activated.

### Summary

<!-- Please explain the purpose, and **link** any relevant issues-->

..

### Changes

-
