### PR TITLE
Text to speech plugin fixes

### DIFF
--- a/text-to-speech/README.md
+++ b/text-to-speech/README.md
@@ -1,6 +1,6 @@
 ## Features
 
-- Provides text to speech buttons in the flashcard queue, as well as an optional auto-play mode.
+- Provides text to speech buttons in the flashcard queue, as well as an optional auto-play mode. (note: autoplay may not work correctly for the front of the card on some browsers due to browser limitations)
 
 ## How to Use
 

--- a/text-to-speech/public/manifest.json
+++ b/text-to-speech/public/manifest.json
@@ -16,7 +16,7 @@
     "patch": 67
   },
   "repoUrl": "https://github.com/remnoteio/remnote-official-plugins",
-  "requestNative": false,
+  "requestNative": true,
   "requiredScopes": [
     {
       "type": "All",

--- a/text-to-speech/public/manifest.json
+++ b/text-to-speech/public/manifest.json
@@ -8,7 +8,7 @@
   "version": {
     "major": 0,
     "minor": 0,
-    "patch": 1
+    "patch": 2
   },
   "minimumRemNoteVersion": {
     "major": 1,

--- a/text-to-speech/src/widgets/index.tsx
+++ b/text-to-speech/src/widgets/index.tsx
@@ -72,6 +72,7 @@ async function onActivate(plugin: ReactRNPlugin) {
       const contextRem = await plugin.rem.findOne(remId);
 
       if (await contextRem?.hasPowerup("textToSpeechPlugin")) {
+        speechSynthesis.cancel()
         contextRem?.removePowerup("textToSpeechPlugin");
         plugin.app.toast("Text to Speech disabled!");
       } else {

--- a/text-to-speech/src/widgets/index.tsx
+++ b/text-to-speech/src/widgets/index.tsx
@@ -72,7 +72,7 @@ async function onActivate(plugin: ReactRNPlugin) {
       const contextRem = await plugin.rem.findOne(remId);
 
       if (await contextRem?.hasPowerup("textToSpeechPlugin")) {
-        speechSynthesis.cancel()
+        speechSynthesis.cancel();
         contextRem?.removePowerup("textToSpeechPlugin");
         plugin.app.toast("Text to Speech disabled!");
       } else {
@@ -97,6 +97,19 @@ async function onActivate(plugin: ReactRNPlugin) {
     },
   });
 
+  plugin.settings.registerDropdownSetting({
+    id: "text-to-speech-voice",
+    title: "Voice",
+    description: "Select the voice to use for text to speech",
+    defaultValue: "Google US English",
+    options: speechSynthesis.getVoices().map((voice, i) => ({
+      key: i.toString(),
+      label: `${voice.name} (${voice.lang})`,
+      value: voice.name,
+    })),
+  });
+
+  // This doesn't seem to always fire on some browsers but Chrome needs it
   speechSynthesis.onvoiceschanged = () => {
     plugin.settings.registerDropdownSetting({
       id: "text-to-speech-voice",

--- a/text-to-speech/src/widgets/text-to-speech.tsx
+++ b/text-to-speech/src/widgets/text-to-speech.tsx
@@ -144,13 +144,14 @@ function TextToSpeechWidget() {
     utterance.voice = utteranceVoice;
 
     // "Debounce" the speaking
-    currentlySpeaking.current = true;
-
-    speechSynthesis.speak(utterance);
-
+    utterance.onstart = () => {
+      currentlySpeaking.current = true;
+    };
     utterance.onend = () => {
       currentlySpeaking.current = false;
     };
+
+    speechSynthesis.speak(utterance);
   };
 
   return hasTextToSpeechPowerup ? (

--- a/text-to-speech/src/widgets/text-to-speech.tsx
+++ b/text-to-speech/src/widgets/text-to-speech.tsx
@@ -11,7 +11,7 @@ import {
   CardType,
   RichTextInterface,
 } from "@remnote/plugin-sdk";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 function TextToSpeechWidget() {
   const plugin = usePlugin();
@@ -69,6 +69,12 @@ function TextToSpeechWidget() {
     },
     [autoPlayEnabled, showAnswer]
   );
+
+  useEffect(() => {
+    return () => {
+      cancelSpeak();
+    }
+  }, [])
 
   useAPIEventListener(QueueEvent.RevealAnswer, undefined, () => {
     cancelSpeak();
@@ -171,6 +177,9 @@ function TextToSpeechWidget() {
     // https://bugs.chromium.org/p/chromium/issues/detail?id=1176078 :(
     // @ts-ignore
     if (window?.chrome) {
+      speechSynthesis.pause();
+      speechSynthesis.resume();
+      
       speakingHackIntervalRef.current = setInterval(() => {
         speechSynthesis.pause();
         speechSynthesis.resume();

--- a/text-to-speech/src/widgets/text-to-speech.tsx
+++ b/text-to-speech/src/widgets/text-to-speech.tsx
@@ -169,10 +169,13 @@ function TextToSpeechWidget() {
     };
 
     // https://bugs.chromium.org/p/chromium/issues/detail?id=1176078 :(
-    speakingHackIntervalRef.current = setInterval(() => {
-      speechSynthesis.pause();
-      speechSynthesis.resume();
-    }, 10_000);
+    // @ts-ignore
+    if (window?.chrome) {
+      speakingHackIntervalRef.current = setInterval(() => {
+        speechSynthesis.pause();
+        speechSynthesis.resume();
+      }, 10_000);
+    }
   };
 
   return hasTextToSpeechPowerup ? (

--- a/text-to-speech/src/widgets/text-to-speech.tsx
+++ b/text-to-speech/src/widgets/text-to-speech.tsx
@@ -15,7 +15,6 @@ import { useRef, useState } from "react";
 
 function TextToSpeechWidget() {
   const plugin = usePlugin();
-  const voices = useRef<SpeechSynthesisVoice[]>();
   const currentlySpeaking = useRef(false);
   const [showAnswer, setShowAnswer] = useState(false);
   const [autoPlayEnabled] = useSyncedStorageState<boolean>(
@@ -75,10 +74,6 @@ function TextToSpeechWidget() {
     currentlySpeaking.current = false;
     setShowAnswer(true);
   });
-
-  speechSynthesis.onvoiceschanged = () => {
-    voices.current = speechSynthesis.getVoices();
-  };
 
   const getFrontText = async (contextRem?: Rem, cardType?: CardType) => {
     const isCloze = typeof cardType === "object" && "clozeId" in cardType;
@@ -142,13 +137,11 @@ function TextToSpeechWidget() {
 
     const utterance = new SpeechSynthesisUtterance(text);
 
-    const utteranceVoice =
-      voice && voices?.current
-        ? voices.current.find((v) => v.name === voice)
-        : undefined;
-    if (utteranceVoice) {
-      utterance.voice = utteranceVoice;
-    }
+    const utteranceVoice = voice
+      ? speechSynthesis.getVoices().find((v) => v.name === voice) ?? null
+      : null;
+
+    utterance.voice = utteranceVoice;
 
     // "Debounce" the speaking
     currentlySpeaking.current = true;


### PR DESCRIPTION
### Summary

<!-- Please explain the purpose, and **link** any relevant issues-->

- **Bug**: Pressing the voice button would only work after pressing "Show Answer" on Chrome with autoplay. This wasn't the case on localhost.
    - **Cause**: `currentlySpeaking.current` was getting stuck at "true" here due to autoplay. Apparently autoplay is only allowed in Chrome after user interaction, but the `speak` function was still getting called without the `onend` event getting triggered.
    - **Fix**: Removed the "debounce" entirely, added cancels on various events, and added a stop button.
 - **Bug**: Voice setting not working on Firefox, stuck with the default voice
    - **Cause**: `onvoiceschanged` doesn't (always?) get fired here, so `voices.current` was always undefined.
    - **Fix**: Now fetching voices inline, the above was an unnecessary optimization.
- **Bug**: Dropdown setting sometimes didn't appear on Firefox
    - **Cause**: Similar to above.
    - **Fix**: Register the identical setting twice with the same ID, one within the `onvoiceschanged` callback.
- **Bug**: Speaking stops after a while on Chrome
    - **Cause**: Browser bug (https://bugs.chromium.org/p/chromium/issues/detail?id=1176078)
    - **Fix**: Set an interval to pause then resume the speech.
    
### Changes

-
