### PR TITLE
feat: add quickCode for Hide in Queue command

### DIFF
--- a/hide-in-queue/src/widgets/index.tsx
+++ b/hide-in-queue/src/widgets/index.tsx
@@ -101,6 +101,7 @@ async function onActivate(plugin: ReactRNPlugin) {
 	await plugin.app.registerCommand({
 		id: `${HIDE_IN_QUEUE_POWERUP_CODE}Cmd`,
 		name: "Hide in Queue",
+		quickCode: "hiq",
 		action: async () => {
 			await runAddPowerupCommand(HIDE_IN_QUEUE_POWERUP_CODE);
 		},

--- a/hide-in-queue/src/widgets/index.tsx
+++ b/hide-in-queue/src/widgets/index.tsx
@@ -84,6 +84,8 @@ async function onActivate(plugin: ReactRNPlugin) {
 	await plugin.app.registerCommand({
 		id: `${NO_HIERARCHY_POWERUP_CODE}Cmd`,
 		name: "No Hierarchy",
+		description: `Any ancestors will be hidden on the front and back of the flashcard.`,
+		quickCode: "nh",
 		action: async () => {
 			await runAddPowerupCommand(NO_HIERARCHY_POWERUP_CODE);
 		},
@@ -101,6 +103,7 @@ async function onActivate(plugin: ReactRNPlugin) {
 	await plugin.app.registerCommand({
 		id: `${HIDE_IN_QUEUE_POWERUP_CODE}Cmd`,
 		name: "Hide in Queue",
+		description: `Hide the tagged Rem in the queue, displaying only “Hidden in Queue."`,
 		quickCode: "hiq",
 		action: async () => {
 			await runAddPowerupCommand(HIDE_IN_QUEUE_POWERUP_CODE);
@@ -119,6 +122,8 @@ async function onActivate(plugin: ReactRNPlugin) {
 	await plugin.app.registerCommand({
 		id: `${REMOVE_FROM_QUEUE_POWERUP_CODE}Cmd`,
 		name: "Remove from Queue",
+		description: `Completely remove the tagged Rem from the queue view.`,
+		quickCode: "rfq",
 		action: async () => {
 			await runAddPowerupCommand(REMOVE_FROM_QUEUE_POWERUP_CODE);
 		},


### PR DESCRIPTION
This pull request includes a small change to the `hide-in-queue/src/widgets/index.tsx` file. The change adds a `quickCode` property to the "Hide in Queue" command registration. 

* [`hide-in-queue/src/widgets/index.tsx`](diffhunk://#diff-350f8191e6afcbfaad21e2bf152bdb4e072f59ea9222a8e99a4c4ff39fe90fdfR104): Added `quickCode: "hiq"` to the command registration for "Hide in Queue".
Fixes #64 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a shorthand access code for the "No Hierarchy," "Hide in Queue," and "Remove from Queue" powerups, enabling quicker activation.
  - Added descriptive explanations for each command, enhancing clarity for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->